### PR TITLE
Lock omniauth-oauth2 to 1.3.x

### DIFF
--- a/omniauth-greenhouse.gemspec
+++ b/omniauth-greenhouse.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
 
-  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1'
+  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.3.1'
   spec.add_runtime_dependency 'omniauth', '>= 1.3.1', '< 2'
 end


### PR DESCRIPTION
omniauth-oauth2 version 1.4.x breaks the OAuth2 dance.

See https://github.com/intridea/omniauth-oauth2/issues/81