### PR TITLE
Adds user info to the auth response

### DIFF
--- a/lib/omniauth/strategies/greenhouse.rb
+++ b/lib/omniauth/strategies/greenhouse.rb
@@ -3,6 +3,23 @@ module OmniAuth
     class Greenhouse < OmniAuth::Strategies::OAuth2
       option :name, 'greenhouse'
       option :client_options, { :site => "https://api.greenhouse.io" }
+
+      info do
+        {
+          :name => "#{raw_info['first_name']} #{raw_info['last_name']}",
+          :email => raw_info['email']
+        }
+      end
+
+      extra do
+        {
+          'raw_info' => raw_info
+        }
+      end
+
+      def raw_info
+        @raw_info ||= access_token.get('/v1/partner/current_user').parsed
+      end
     end
   end
 end


### PR DESCRIPTION
@mindmatch uses greenhouse oauth for identifying 
the current user, but the current version of the library
does not set any user info.

For convenience of users oAuth already provides 
a suggested way to retrieve and set user information 
after a successful attempt. 

This PR implements setting of user info like described on omniauth-oauth2 readme:
https://github.com/omniauth/omniauth-oauth2/blob/master/README.md 