### PR TITLE
Update omniauth-greenhouse gemspec details

### DIFF
--- a/omniauth-greenhouse.gemspec
+++ b/omniauth-greenhouse.gemspec
@@ -4,13 +4,20 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'omniauth-greenhouse'
-  spec.version       = '1.3.1'
-  spec.authors       = %w(timothy.frey)
+  spec.version       = '1.3.2'
+  spec.authors       = %w(Greenhouse Software)
   spec.email         = %w(tech@greenhouse.io)
   spec.description   = 'Integrate with Greenhouse with OmniAuth'
   spec.summary       = 'Integrate with Greenhouse with OmniAuth'
-  spec.homepage      = 'http://greenhouse.io'
+  spec.homepage      = "https://github.com/grnhse/omniauth-greenhouse"
   spec.license       = 'MIT'
+
+  spec.post_install_message = %q{
+    omniauth-greenhouse will be removed from Rubygems on Friday, April 3, 2026.
+    Please install using a direct link to the Github repo:
+    
+    gem "omniauth-greenhouse", git: "git@github.com:grnhse/omniauth-greenhouse.git", branch: "master"
+  }
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/omniauth-greenhouse.gemspec
+++ b/omniauth-greenhouse.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.post_install_message = %q{
-    omniauth-greenhouse will be removed from Rubygems on Friday, April 3, 2026.
+    omniauth-greenhouse will be removed from Rubygems.org on Friday, April 3, 2026.
     Please install using a direct link to the Github repo:
     
     gem "omniauth-greenhouse", git: "git@github.com:grnhse/omniauth-greenhouse.git", branch: "master"


### PR DESCRIPTION
Updated version number and authors in the gemspec. Changed homepage URL and added post-install message regarding removal from Rubygems.